### PR TITLE
Add new entity: other

### DIFF
--- a/catalog/component/other/catalog-info.yaml
+++ b/catalog/component/other/catalog-info.yaml
@@ -1,0 +1,18 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: kolibri-other
+  title: Kolibri other
+  description: other component for Kolibri
+  annotations:
+    backstage.io/source-location: url:https://github.com/learningequality/kolibri/
+  links:
+    - url: https://kolibri-dev.readthedocs.io/en/develop/
+      title: Kolibri developer documentation
+      icon: documentation
+      type: documentation
+spec:
+  type: website
+  owner: team-kolibri
+  lifecycle: production
+  systems: kolibri-system


### PR DESCRIPTION
This PR adds a new NaN entity, named `other` to the Kolibri catalog.