### PR TITLE
Add new components named backend2

### DIFF
--- a/catalog/components/backend2/catalog-info.yaml
+++ b/catalog/components/backend2/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: kolibri-backend2
+  title: Kolibri backend2
+  description: backend2 components for Kolibri
+  annotations:
+    backstage.io/source-location: url:https://github.com/learningequality/kolibri/
+  links:
+    - url: https://kolibri-dev.readthedocs.io/en/develop/
+      title: Kolibri developer documentation
+spec:
+  type: website
+  owner: team-kolibri
+  lifecycle: production
+  systems: kolibri-system


### PR DESCRIPTION
This PR adds a new components, named `backend2` to the Kolibri catalog.