### PR TITLE
Add new components named backend3

### DIFF
--- a/catalog/apis/swagger-api/catalog-info.yaml
+++ b/catalog/apis/swagger-api/catalog-info.yaml
@@ -9,4 +9,4 @@ spec:
   owner: team-kolibri
   system: kolibri-system
   definition:
-    $json: 'https://gist.githubusercontent.com/lenage/08964335de9064540c8c335fb849c5da/raw/6d63e3546897356882ed7e30cd48891a24e2b354/feature.swagger.json'
+    $text: 'https://gist.githubusercontent.com/lenage/08964335de9064540c8c335fb849c5da/raw/6d63e3546897356882ed7e30cd48891a24e2b354/feature.swagger.json'

--- a/catalog/apis/swagger-api/catalog-info.yaml
+++ b/catalog/apis/swagger-api/catalog-info.yaml
@@ -9,4 +9,4 @@ spec:
   owner: team-kolibri
   system: kolibri-system
   definition:
-    $file: 'https://gist.githubusercontent.com/lenage/08964335de9064540c8c335fb849c5da/raw/6d63e3546897356882ed7e30cd48891a24e2b354/feature.swagger.json'
+    $json: 'https://gist.githubusercontent.com/lenage/08964335de9064540c8c335fb849c5da/raw/6d63e3546897356882ed7e30cd48891a24e2b354/feature.swagger.json'

--- a/catalog/components/backend3/catalog-info.yaml
+++ b/catalog/components/backend3/catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: kolibri-backend3
+  title: Kolibri backend3
+  description: backend3 components for Kolibri
+  annotations:
+    backstage.io/source-location: url:https://github.com/learningequality/kolibri/
+  links:
+    - url: https://kolibri-dev.readthedocs.io/en/develop/
+      title: Kolibri developer documentation
+spec:
+  type: website
+  owner: team-kolibri
+  lifecycle: production
+  systems: kolibri-system


### PR DESCRIPTION
This PR adds a new components, named `backend3` to the Kolibri catalog.